### PR TITLE
Add global scopes from the builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Latest Stable Version](https://poser.pugx.org/lgrevelink/laravel-custom-query-builder/v/stable.svg)](https://packagist.org/packages/lgrevelink/laravel-custom-query-builder)
 [![License](https://poser.pugx.org/lgrevelink/laravel-custom-query-builder/license.svg)](https://github.com/larsgrevelink/laravel-custom-query-builder)
 
-A custom query builder which allows projects to use Eloquent's builder on an application level. Define joins, filters and sorting methods with proper IntelliSense through a thin abstraction layer. It's a different approach to Laravel's local scopes.
+A custom query builder which allows projects to use Eloquent's builder on an application level. Define joins, filters, sorting and scopes with proper IntelliSense through a thin abstraction layer.
 
 ## Installation
 
@@ -98,6 +98,19 @@ $builder->applySorting([
     'category' => 'asc',
     'title' => 'asc',
 ]); // Calls both sortByCategory and sortByTitle
+```
+
+#### Global scopes directly from the builder
+
+If you want to keep all database related data, including global scopes, in the query builder; you can! They are only added when the models dictate that they should be added but it keeps you from having to add these through the `Model->boot` functions.
+
+```php
+class MyQueryBuilder extends CustomQueryBuilder
+{
+    protected $globalScopes = [
+        MyScope::class,
+    ];
+}
 ```
 
 #### Strict exceptions

--- a/src/Concerns/HasCustomQueryBuilder.php
+++ b/src/Concerns/HasCustomQueryBuilder.php
@@ -2,8 +2,6 @@
 
 namespace LGrevelink\CustomQueryBuilder\Concerns;
 
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Query\Builder as QueryBuilder;
 use LGrevelink\CustomQueryBuilder\Database\Eloquent\CustomQueryBuilder;
 
 trait HasCustomQueryBuilder
@@ -31,14 +29,23 @@ trait HasCustomQueryBuilder
     }
 
     /**
-     * Create a new Eloquent query builder for the model.
-     *
-     * @param QueryBuilder $query
-     *
-     * @return Builder
+     * @inheritdoc
      */
     public function newEloquentBuilder($query)
     {
         return new $this->queryBuilder($query);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function registerGlobalScopes($builder)
+    {
+        // Trigger a builder's registerGlobalScopes when present
+        if (method_exists($builder, 'registerGlobalScopes')) {
+            $builder->registerGlobalScopes();
+        }
+
+        return parent::registerGlobalScopes($builder);
     }
 }

--- a/src/Database/Eloquent/CustomQueryBuilder.php
+++ b/src/Database/Eloquent/CustomQueryBuilder.php
@@ -40,6 +40,13 @@ class CustomQueryBuilder extends Builder
     protected $defaultSortingDirection = 'asc';
 
     /**
+     * Default global scopes which are added when requested by the model.
+     *
+     * @var array
+     */
+    protected $globalScopes = [];
+
+    /**
      * Apply a set of filter clauses to the query.
      *
      * @param array $filters
@@ -160,6 +167,20 @@ class CustomQueryBuilder extends Builder
 
         if (!$join) {
             $this->query->join($table, $first, $operator, $second, $type, $where);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Registers the custom query builder's global scopes on the instance.
+     *
+     * @return $this
+     */
+    public function registerGlobalScopes()
+    {
+        foreach ($this->globalScopes as $scope) {
+            $this->withGlobalScope($scope, new $scope());
         }
 
         return $this;


### PR DESCRIPTION
Small feature addition which allows for adding global scopes from the builders directly instead of the model's boot function.